### PR TITLE
Remove unused time import

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -4,8 +4,12 @@ import re
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
-from src.config import DEFAULT_MIN_SECONDS_BETWEEN_REQUESTS, DEFAULT_TEST_REQUEST_TIMEOUT, DEFAULT_TEST_NO_DELAY_THRESHOLD, DEFAULT_MIN_CONTENT_LENGTH
-import time
+from src.config import (
+    DEFAULT_MIN_SECONDS_BETWEEN_REQUESTS,
+    DEFAULT_TEST_REQUEST_TIMEOUT,
+    DEFAULT_TEST_NO_DELAY_THRESHOLD,
+    DEFAULT_MIN_CONTENT_LENGTH,
+)
 
 from src.scraper import extract_text_from_url, get_domain_from_url, apply_rate_limiting
 


### PR DESCRIPTION
## Summary
- clean up unused import in scraper tests

## Testing
- `pytest -q` *(fails: playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b235d9dac8333a8c926e556f744f6