### PR TITLE
Add explicit max_length parameter to scraper

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -131,7 +131,13 @@ async def serve(custom_user_agent: str | None = None):
 
         # Call our existing scraper function
         logger.info(f"Scraping URL: {url}")
-        result = await extract_text_from_url(url, custom_timeout=args.timeout_seconds, custom_elements_to_remove=None, grace_period_seconds=args.grace_period_seconds)
+        result = await extract_text_from_url(
+            url,
+            custom_timeout=args.timeout_seconds,
+            custom_elements_to_remove=None,
+            grace_period_seconds=args.grace_period_seconds,
+            max_length=args.max_length,
+        )
 
         if result.get("error"):
             logger.error(

--- a/src/scraper/__init__.py
+++ b/src/scraper/__init__.py
@@ -49,7 +49,8 @@ def extract_and_format_content(html_content, elements_to_remove, url):
 async def extract_text_from_url(url: str,
                                 custom_elements_to_remove: list = None,
                                 custom_timeout: int = None,
-                                grace_period_seconds: float = 2.0) -> dict:
+                                grace_period_seconds: float = 2.0,
+                                max_length: int | None = None) -> dict:
     """Return primary text content from a web page.
 
     Parameters
@@ -62,6 +63,8 @@ async def extract_text_from_url(url: str,
         Override the default timeout value in seconds.
     grace_period_seconds : float, optional
         Time to wait after navigation before reading the page.
+    max_length : int | None, optional
+        If provided, truncate the extracted content to this number of characters.
 
     Returns
     -------
@@ -171,16 +174,6 @@ async def extract_text_from_url(url: str,
                         "error": f"[ERROR] No significant text content extracted (too short, less than {min_content_length} characters)."
                     }
                 else:
-                    max_length = None
-                    import inspect
-
-                    frame = inspect.currentframe()
-                    while frame:
-                        if 'max_length' in frame.f_locals:
-                            max_length = frame.f_locals['max_length']
-                            break
-                        frame = frame.f_back
-
                     if max_length is not None:
                         text = text[:max_length]
                         markdown_content = markdown_content[:max_length]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,7 +10,7 @@ async def test_call_tool_with_string_result():
         "timeout_seconds": 30,
         "wait_for_network_idle": True
     }
-    result = await mcp_extract_text_map(arguments["url"])
+    result = await mcp_extract_text_map(arguments["url"], max_length=arguments["max_length"])
     assert isinstance(result, dict)
     assert "status" in result
     assert "extracted_text" in result

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -29,6 +29,15 @@ async def test_extract_text_from_example_com():
 
 
 @pytest.mark.asyncio
+async def test_extract_text_from_example_com_with_max_length():
+    url = "https://example.com"
+    result = await extract_text_from_url(url, max_length=50)
+    assert isinstance(result, dict)
+    assert result.get("markdown_content") is not None
+    assert len(result.get("markdown_content")) <= 50
+
+
+@pytest.mark.asyncio
 async def test_extract_text_from_wikipedia():
     url = "https://en.wikipedia.org/wiki/Web_scraping"
     result = await extract_text_from_url(url)


### PR DESCRIPTION
## Summary
- allow consumers to set `max_length` when scraping text
- send `args.max_length` through MCP server
- test scraper truncation with max length
- update MCP tests to use the new argument

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q setuptools`
- `pytest -q` *(fails: BrowserType.launch executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b2c2325d8833398b87361efc513a7