### PR TITLE
Add update-ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpangocairo-1.0-0 libxss1 \
     wget gnupg curl ca-certificates fonts-liberation libappindicator3-1 \
     lsb-release xdg-utils git && \
+    update-ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- run `update-ca-certificates` during Docker build so HTTPS certificates are correctly installed

## Testing
- `docker compose build test` *(fails: `docker: command not found`)*
- `pytest -q` *(fails: ModuleNotFoundError: pkg_resources)*

------
https://chatgpt.com/codex/tasks/task_e_684b31dbc34c8333a0685178354fd939