### PR TITLE
Add user agent and network idle options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This web scraper is used as an MCP (Model Context Protocol) tool, allowing it to
 - `url` (string, required): The URL to scrape
 - `max_length` (integer, optional): Maximum length of returned content (default: 5000)
 - `timeout_seconds` (integer, optional): Timeout in seconds for the page load (default: 30)
-- `user_agent` (string, optional): Custom User-Agent string
-- `wait_for_network_idle` (boolean, optional): Whether to wait for network activity to settle (default: true)
+- `user_agent` (string, optional): Custom User-Agent string passed directly to the browser (defaults to a random agent)
+- `wait_for_network_idle` (boolean, optional): Wait for network activity to settle before scraping (default: true)
 - `custom_elements_to_remove` (list, optional): Additional HTML elements to remove
 - `grace_period_seconds` (float, optional): Short grace period to allow JS to finish rendering (in seconds, default: 2.0)
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -136,6 +136,8 @@ async def serve(custom_user_agent: str | None = None):
             custom_elements_to_remove=None,
             grace_period_seconds=args.grace_period_seconds,
             max_length=args.max_length,
+            user_agent=args.user_agent,
+            wait_for_network_idle=args.wait_for_network_idle,
         )
 
         if result.get("error"):

--- a/src/scraper/helpers/content_selectors.py
+++ b/src/scraper/helpers/content_selectors.py
@@ -4,14 +4,15 @@ from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 logger = Logger(__name__)
 
 
-async def _wait_for_content_stabilization(page, domain, timeout_seconds):
-    try:
-        await page.wait_for_load_state("networkidle", timeout=timeout_seconds * 1000 / 2)
-        logger.debug("Network became idle")
+async def _wait_for_content_stabilization(page, domain, timeout_seconds, wait_for_network_idle=True):
+    if wait_for_network_idle:
+        try:
+            await page.wait_for_load_state("networkidle", timeout=timeout_seconds * 1000 / 2)
+            logger.debug("Network became idle")
 
-    except PlaywrightTimeoutError:
-        logger.debug(
-            f"Network didn't become fully idle after {timeout_seconds/2}s, continuing anyway")
+        except PlaywrightTimeoutError:
+            logger.debug(
+                f"Network didn't become fully idle after {timeout_seconds/2}s, continuing anyway")
 
     try:
         await page.wait_for_selector('body', timeout=timeout_seconds * 1000 / 2)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,7 @@
 import pytest
+import random
 from src.mcp_server import mcp_extract_text_map
+from src.scraper.helpers.browser import USER_AGENTS
 
 
 @pytest.mark.asyncio
@@ -8,9 +10,15 @@ async def test_call_tool_with_string_result():
         "url": "http://example.com",
         "max_length": None,
         "timeout_seconds": 30,
-        "wait_for_network_idle": True
+        "wait_for_network_idle": True,
+        "user_agent": random.choice(USER_AGENTS),
     }
-    result = await mcp_extract_text_map(arguments["url"], max_length=arguments["max_length"])
+    result = await mcp_extract_text_map(
+        arguments["url"],
+        max_length=arguments["max_length"],
+        user_agent=arguments["user_agent"],
+        wait_for_network_idle=arguments["wait_for_network_idle"],
+    )
     assert isinstance(result, dict)
     assert "status" in result
     assert "extracted_text" in result

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -2,6 +2,7 @@ import pytest
 import asyncio
 import re
 import requests
+import random
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
 from src.config import (
@@ -12,6 +13,7 @@ from src.config import (
 )
 
 from src.scraper import extract_text_from_url, get_domain_from_url, apply_rate_limiting
+from src.scraper.helpers.browser import USER_AGENTS
 
 
 @pytest.mark.asyncio
@@ -233,3 +235,16 @@ async def test_grace_period_seconds_js_delay():
     # The longer grace period should yield more content
     assert len(result_long.get("markdown_content") or "") > len(result_short.get(
         "markdown_content") or ""), "Longer grace period did not capture more content."
+
+
+@pytest.mark.asyncio
+async def test_custom_user_agent_and_no_network_idle():
+    url = "https://example.com"
+    result = await extract_text_from_url(
+        url,
+        user_agent=random.choice(USER_AGENTS),
+        wait_for_network_idle=False,
+    )
+    assert isinstance(result, dict)
+    assert result.get("markdown_content") is not None
+    assert not result.get("error")


### PR DESCRIPTION
## Summary
- integrate custom user agent and wait_for_network_idle options in scraper
- expose these options via MCP server
- clarify README parameter descriptions
- test coverage for new arguments
- use randomized user agents in tests

## Testing
- `docker compose up --build --abort-on-container-exit test` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684b33b0a9988333adc53032b2a6b9bc